### PR TITLE
Implement product detail navigation

### DIFF
--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -1,0 +1,58 @@
+export type Product = {
+  id: number;
+  name: string;
+  price: number;
+  image: string;
+  description: string;
+  /**
+   * More detailed information about the product that is displayed on the detail
+   * page. This should provide shoppers with extra context and selling points.
+   */
+  details: string;
+  /** Category name used on the detail page */
+  category: string;
+  /** Product rating from 0 to 5 */
+  rating: number;
+};
+
+export const products: Product[] = [
+  {
+    id: 1,
+    name: "Stylish Shoes",
+    price: 59.99,
+    image:
+      "https://images.unsplash.com/photo-1519744792095-2f2205e87b6f?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Comfortable and stylish shoes perfect for any occasion.",
+    details:
+      "These shoes are crafted from premium leather and feature a cushioned sole for all-day comfort.",
+    category: "Footwear",
+    rating: 4.5,
+  },
+  {
+    id: 2,
+    name: "Elegant Watch",
+    price: 199.99,
+    image:
+      "https://images.unsplash.com/photo-1518544804389-9f7ac5d513c8?auto=format&fit=crop&w=800&q=60",
+    description:
+      "A sleek watch that adds a touch of sophistication to your outfit.",
+    details:
+      "Features a stainless steel case, genuine leather strap and water resistance up to 50 meters.",
+    category: "Accessories",
+    rating: 4.8,
+  },
+  {
+    id: 3,
+    name: "Comfy Headphones",
+    price: 89.99,
+    image:
+      "https://images.unsplash.com/photo-1512314889357-e157c22f938d?auto=format&fit=crop&w=800&q=60",
+    description:
+      "Experience high-quality sound with these over-ear headphones.",
+    details:
+      "Wireless headphones offering noise isolation, Bluetooth connectivity and a 20-hour battery life.",
+    category: "Electronics",
+    rating: 4.2,
+  },
+];

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,7 @@ import {
   Link,
 } from "@remix-run/react";
 import type { LinksFunction } from "@remix-run/node";
+import { CartProvider, useCart } from "~/utils/cart";
 
 import "./tailwind.css";
 
@@ -41,26 +42,41 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
+function Navigation() {
+  const { items } = useCart();
+  const count = items.reduce((sum, i) => sum + i.quantity, 0);
+  return (
+    <header className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur">
+      <nav className="container mx-auto flex items-center justify-between p-4">
+        <Link to="/" className="text-xl font-bold">
+          Acme Store
+        </Link>
+        <ul className="flex gap-4">
+          <li>
+            <Link to="/products" className="hover:underline">
+              Products
+            </Link>
+          </li>
+          <li>
+            <Link to="/cart" className="hover:underline">
+              Cart ({count})
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}
+
 export default function App() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="border-b">
-        <nav className="container mx-auto flex items-center justify-between p-4">
-          <Link to="/" className="text-xl font-bold">
-            Acme Store
-          </Link>
-          <ul className="flex gap-4">
-            <li>
-              <Link to="/products" className="hover:underline">
-                Products
-              </Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main className="flex-grow">
-        <Outlet />
-      </main>
-    </div>
+    <CartProvider>
+      <div className="min-h-screen flex flex-col">
+        <Navigation />
+        <main className="flex-grow">
+          <Outlet />
+        </main>
+      </div>
+    </CartProvider>
   );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,6 @@
 import type { MetaFunction } from "@remix-run/node";
 import { Link } from "@remix-run/react";
+import { products } from "~/data/products";
 
 export const meta: MetaFunction = () => [
   { title: "Acme Store" },
@@ -7,18 +8,120 @@ export const meta: MetaFunction = () => [
 ];
 
 export default function Index() {
+  const features = [
+    {
+      name: "Free Shipping",
+      description: "On all orders over $50",
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-6 w-6"
+        >
+          <path
+            d="M3 3h13v13H3V3zm14 13h4.586L19 12.414V16zM17 3v9h3.586L23 12.414V3h-6zM1 18h2a3 3 0 106 0h6a3 3 0 106 0h2v2H1v-2z"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "24/7 Support",
+      description: "We are here to help anytime",
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-6 w-6"
+        >
+          <path
+            d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 14h-2v-2h2v2zm0-4h-2V6h2v6z"
+          />
+        </svg>
+      ),
+    },
+    {
+      name: "Secure Payments",
+      description: "Your information is safe with us",
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-6 w-6"
+        >
+          <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z" />
+        </svg>
+      ),
+    },
+  ];
+
   return (
-    <section className="mx-auto flex h-[calc(100vh-4rem)] max-w-4xl flex-col items-center justify-center gap-8 p-4 text-center">
-      <h1 className="text-4xl font-bold">Welcome to Acme Store</h1>
-      <p className="text-lg text-gray-600">
-        Discover the best products from our curated collection.
-      </p>
-      <Link
-        to="/products"
-        className="rounded bg-blue-600 px-6 py-3 text-white hover:bg-blue-700"
-      >
-        Shop Now
-      </Link>
-    </section>
+    <>
+      <section className="relative flex h-[calc(100vh-4rem)] items-center justify-center overflow-hidden">
+        <img
+          src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=1400&q=60"
+          alt="Shopping banner"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+        <div className="absolute inset-0 bg-gradient-to-br from-black/70 to-black/30" />
+        <div className="relative z-10 text-center text-white p-8">
+          <h1 className="mb-4 text-5xl font-bold">Shop the Latest Trends</h1>
+          <p className="mb-6 text-lg">Discover the best products from our curated collection.</p>
+          <Link
+            to="/products"
+            className="rounded bg-blue-600 px-6 py-3 font-medium hover:bg-blue-700"
+          >
+            Shop Now
+          </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl p-8 text-center">
+        <h2 className="mb-8 text-3xl font-semibold">Why shop with us?</h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          {features.map((feature) => (
+            <div key={feature.name} className="flex flex-col items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white">
+                {feature.icon}
+              </div>
+              <h3 className="text-lg font-semibold">{feature.name}</h3>
+              <p className="text-gray-600">{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl p-8">
+        <h2 className="mb-6 text-center text-3xl font-semibold">Featured Products</h2>
+        <ul className="grid gap-6 md:grid-cols-3">
+          {products.map((p) => (
+            <li key={p.id} className="flex flex-col items-center rounded border p-4 text-center">
+              <img src={p.image} alt={p.name} className="mb-2 h-40 w-full rounded object-cover" />
+              <h3 className="font-semibold">{p.name}</h3>
+              <p className="mb-2 text-gray-600">${p.price.toFixed(2)}</p>
+              <Link
+                to={`/products/${p.id}`}
+                className="rounded border px-3 py-2 text-blue-600 hover:bg-gray-100"
+              >
+                View details
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mx-auto max-w-3xl p-8 text-center">
+        <h2 className="mb-4 text-3xl font-semibold">Ready to elevate your style?</h2>
+        <p className="mb-6 text-gray-700">Browse our catalog and find your perfect match.</p>
+        <Link
+          to="/products"
+          className="rounded bg-blue-600 px-6 py-3 font-medium text-white hover:bg-blue-700"
+        >
+          Start Shopping
+        </Link>
+      </section>
+    </>
   );
 }

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -1,0 +1,74 @@
+import { Link } from "@remix-run/react";
+import type { MetaFunction } from "@remix-run/node";
+import { useCart } from "~/utils/cart";
+
+export const meta: MetaFunction = () => [{ title: "Cart - Acme Store" }];
+
+export default function Cart() {
+  const { items, removeItem, updateQuantity, clearCart } = useCart();
+
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  return (
+    <div className="mx-auto max-w-4xl p-4">
+      <h1 className="mb-6 text-2xl font-bold">Your Cart</h1>
+      {items.length === 0 ? (
+        <p>Your cart is empty.</p>
+      ) : (
+        <>
+          <ul className="space-y-4">
+            {items.map((item) => (
+              <li key={item.id} className="flex gap-4 border-b pb-4 last:border-b-0">
+                <img src={item.image} alt={item.name} className="h-20 w-20 object-cover" />
+                <div className="flex-grow">
+                  <h2 className="font-semibold">{item.name}</h2>
+                  <p className="text-gray-600">${item.price.toFixed(2)}</p>
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}
+                      className="rounded border px-2 py-1"
+                    >
+                      -
+                    </button>
+                    <span>{item.quantity}</span>
+                    <button
+                      onClick={() => updateQuantity(item.id, item.quantity + 1)}
+                      className="rounded border px-2 py-1"
+                    >
+                      +
+                    </button>
+                    <button
+                      onClick={() => removeItem(item.id)}
+                      className="ml-4 text-sm text-red-600 hover:underline"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 flex items-center justify-between">
+            <p className="text-xl font-semibold">Total: ${total.toFixed(2)}</p>
+            <div className="space-x-2">
+              <button
+                onClick={clearCart}
+                className="rounded border px-4 py-2 hover:bg-gray-100"
+              >
+                Clear Cart
+              </button>
+              <button className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+                Checkout
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+      <div className="mt-4">
+        <Link to="/products" className="text-blue-600 hover:underline">
+          Continue Shopping
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/products.$id.tsx
+++ b/app/routes/products.$id.tsx
@@ -1,0 +1,46 @@
+import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import { products } from "~/data/products";
+import { useCart } from "~/utils/cart";
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [{
+  title: data ? `${data.product.name} - Acme Store` : "Product - Acme Store",
+}];
+
+export function loader({ params }: LoaderFunctionArgs) {
+  const product = products.find((p) => p.id.toString() === params.id);
+  if (!product) {
+    throw new Response("Not found", { status: 404 });
+  }
+  return { product };
+}
+
+export default function ProductDetail() {
+  const { product } = useLoaderData<typeof loader>();
+  const { addItem } = useCart();
+
+  return (
+    <div className="mx-auto max-w-4xl p-4">
+      <Link to="/products" className="text-blue-600 hover:underline">
+        &larr; Back to products
+      </Link>
+      <div className="mt-4 grid gap-6 md:grid-cols-2">
+        <img src={product.image} alt={product.name} className="w-full rounded object-cover" />
+        <div className="space-y-4">
+          <h1 className="text-3xl font-bold">{product.name}</h1>
+          <p className="text-gray-600">{product.description}</p>
+          <p className="font-medium">Category: {product.category}</p>
+          <p className="">Rating: {product.rating} / 5</p>
+          <p className="text-gray-700">{product.details}</p>
+          <p className="text-2xl font-semibold">${product.price.toFixed(2)}</p>
+          <button
+            onClick={() => addItem(product)}
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          >
+            Add to Cart
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/products.tsx
+++ b/app/routes/products.tsx
@@ -1,22 +1,46 @@
 import type { MetaFunction } from "@remix-run/node";
+import { Link } from "@remix-run/react";
+import { products } from "~/data/products";
+import { useCart } from "~/utils/cart";
 
 export const meta: MetaFunction = () => [{ title: "Products - Acme Store" }];
 
-const products = [
-  { id: 1, name: "Product 1", price: "$19.99" },
-  { id: 2, name: "Product 2", price: "$29.99" },
-  { id: 3, name: "Product 3", price: "$39.99" },
-];
-
 export default function Products() {
+  const { addItem } = useCart();
   return (
     <div className="mx-auto max-w-4xl p-4">
       <h1 className="mb-6 text-2xl font-bold">Products</h1>
       <ul className="grid grid-cols-1 gap-4 md:grid-cols-3">
         {products.map((p) => (
-          <li key={p.id} className="rounded border p-4">
-            <h2 className="text-lg font-semibold">{p.name}</h2>
-            <p className="text-gray-600">{p.price}</p>
+          <li key={p.id} className="flex flex-col items-center rounded border p-4 text-center">
+            <Link to={`/products/${p.id}`} className="w-full">
+              <img
+                src={p.image}
+                alt={p.name}
+                className="mb-2 h-40 w-full rounded object-cover"
+              />
+            </Link>
+            <Link
+              to={`/products/${p.id}`}
+              className="text-lg font-semibold hover:underline"
+            >
+              {p.name}
+            </Link>
+            <p className="text-gray-600">${p.price.toFixed(2)}</p>
+            <div className="mt-2 flex w-full gap-2">
+              <Link
+                to={`/products/${p.id}`}
+                className="flex-1 rounded border px-3 py-2 hover:bg-gray-100"
+              >
+                View Details
+              </Link>
+              <button
+                onClick={() => addItem(p)}
+                className="flex-1 rounded bg-blue-600 px-3 py-2 text-white hover:bg-blue-700"
+              >
+                Add to Cart
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/app/utils/cart.tsx
+++ b/app/utils/cart.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+export type CartItem = {
+  id: number;
+  name: string;
+  price: number;
+  image: string;
+  quantity: number;
+};
+
+export type CartContextType = {
+  items: CartItem[];
+  addItem: (item: Omit<CartItem, "quantity">) => void;
+  removeItem: (id: number) => void;
+  updateQuantity: (id: number, quantity: number) => void;
+  clearCart: () => void;
+};
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("cart");
+    if (stored) {
+      try {
+        setItems(JSON.parse(stored));
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("cart", JSON.stringify(items));
+  }, [items]);
+
+  function addItem(item: Omit<CartItem, "quantity">) {
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === item.id);
+      if (existing) {
+        return prev.map((i) =>
+          i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i
+        );
+      }
+      return [...prev, { ...item, quantity: 1 }];
+    });
+  }
+
+  function removeItem(id: number) {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  function updateQuantity(id: number, quantity: number) {
+    setItems((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, quantity } : i))
+    );
+  }
+
+  function clearCart() {
+    setItems([]);
+  }
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, updateQuantity, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("useCart must be used within CartProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- extend product data with details, category and rating
- add 'View Details' buttons on the home and products pages
- show detailed information on the product page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687251d20e4083328d696a77fcffb722